### PR TITLE
Laravel 7 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Version Compatibility
  5.6.x    | 2.6.x
  5.x.x    | 3.3.x  
  6.x.x    | 3.4.x  
+ 7.x.x    | 3.7.x  
 
 Updating Eloquent models
 ------------------------
@@ -287,6 +288,9 @@ vendor/bin/phpunit
 
 Changelog
 ---------
+
+3.7.0
+- Add Laravel 7 support
 
 3.6.0
 - Add `isFirst`, `isNotFirst`, `isLast`, `isNotLast` method

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "5.*|^6.0"
+        "illuminate/support": "5.*|^6.0|^7.*"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench" : "3.*|4.*",
-        "phpunit/phpunit": "6.*|7.*|8.*"
+        "orchestra/testbench" : "3.*|4.*|5.*",
+        "phpunit/phpunit": "6.*|7.*|8.*|9.*"
     },
     "autoload": {
         "psr-4": {
@@ -33,7 +33,7 @@
     },
     "extra": {
         "component": "package",
-        "frameworks": ["Laravel 5.0", "Laravel 5.1", "Laravel 5.2", "Laravel 5.3", "Laravel 5.4", "Laravel 5.5", "Laravel 5.6", "Laravel 5.7"]
+        "frameworks": ["Laravel 5.x", "Laravel 6.x", "Laravel 7.x"]
     },
     "minimum-stability": "stable"
 }


### PR DESCRIPTION
I'm unsure if anything else is required, other than the changes in this PR (the list of frameworks was a purely cosmetic change).  Hopefully this is enough.