### PR TITLE
Support L7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Version Compatibility
  5.6.x    | 2.6.x
  5.x.x    | 3.3.x  
  6.x.x    | 3.4.x  
+ 7.x.x    | 3.7.x  
 
 Updating Eloquent models
 ------------------------
@@ -287,6 +288,9 @@ vendor/bin/phpunit
 
 Changelog
 ---------
+
+3.7.0
+- Laravel 7 support
 
 3.6.0
 - Add `isFirst`, `isNotFirst`, `isLast`, `isNotLast` method

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1.3",
-        "illuminate/support": "5.*|^6.0"
+        "illuminate/support": "5.*|6.*|^7.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "orchestra/testbench" : "3.*|4.*",
-        "phpunit/phpunit": "6.*|7.*|8.*"
+        "orchestra/testbench" : "3.*|4.*|5.*",
+        "phpunit/phpunit": "6.*|7.*|8.*|9.*"
     },
     "autoload": {
         "psr-4": {
@@ -33,7 +33,7 @@
     },
     "extra": {
         "component": "package",
-        "frameworks": ["Laravel 5.0", "Laravel 5.1", "Laravel 5.2", "Laravel 5.3", "Laravel 5.4", "Laravel 5.5", "Laravel 5.6", "Laravel 5.7"]
+        "frameworks": ["Laravel 5.x", "Laravel 6.x", "Laravel 7.x"]
     },
     "minimum-stability": "stable"
 }

--- a/src/SequenceService.php
+++ b/src/SequenceService.php
@@ -508,9 +508,10 @@ class SequenceService
         }
 
         $newGroups = [];
+        $getOriginalMethod = method_exists($this->obj, 'getRawOriginal') ? 'getRawOriginal' : 'getOriginal';
         foreach ($groups as $group) {
             $newGroups[$group] = $this->obj->{$group};
-            $this->obj->{$group} = $this->obj->getOriginal($group);
+            $this->obj->{$group} = $this->obj->{$getOriginalMethod}($group);
         }
 
         $this->updateSequences();


### PR DESCRIPTION
Add support for Laravel 7.
Use of getRawOriginal if available (L7) and getOriginal otherwise, for backward compatibility of the updateSequencesOnGroupChange function.